### PR TITLE
fix string values not being set in structToValues

### DIFF
--- a/util.go
+++ b/util.go
@@ -32,7 +32,7 @@ func structToValues(i interface{}, values url.Values) {
 				v = "1"
 			}
 		case string:
-			f.String()
+			v = f.String()
 		}
 		if v != "" {
 			values.Set(strings.ToLower(typ.Field(i).Name), v)


### PR DESCRIPTION
fixes: string values not being set, thus making stuff like filtering a torrent search with a string value not working
